### PR TITLE
Make cron jobs dependable on project repo

### DIFF
--- a/.github/workflows/baselines.yml
+++ b/.github/workflows/baselines.yml
@@ -3,27 +3,28 @@ name: Baselines
 on:
   workflow_dispatch:
   schedule:
-    - cron: '43 13 * * 0' # runs only on Sundays
-  
+    - cron: "43 13 * * 0" # runs only on Sundays
+
 jobs:
   baselines:
+    if: github.repository_owner == 'rki-daki-fws'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: submit
-    - uses: r-lib/actions/setup-r@v2
-    - uses: r-lib/actions/setup-r-dependencies@v2
-      with:
-        working-directory: './examples'
+      - uses: actions/checkout@v3
+        with:
+          ref: submit
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          working-directory: "./examples"
 
-    - name: Run baseline models
-      run: Rscript examples/baselines.R
+      - name: Run baseline models
+        run: Rscript examples/baselines.R
 
-    - name: Commit & push changes
-      run: |
-        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-        git config --global user.name "${GITHUB_ACTOR}"
-        git add submissions/*
-        git commit -m 'add new baseline submissions'
-        git push
+      - name: Commit & push changes
+        run: |
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name "${GITHUB_ACTOR}"
+          git add submissions/*
+          git commit -m 'add new baseline submissions'
+          git push

--- a/.github/workflows/generate_report.yml
+++ b/.github/workflows/generate_report.yml
@@ -1,45 +1,43 @@
 name: Generate Report
 
 on:
- workflow_run:
+  workflow_run:
     workflows: [Manual report trigger, Evaluate submission]
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-a-workflow-based-on-the-conclusion-of-another-workflow
     types:
       - completed
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   generate:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out your repository, so your job can access it
       - uses: actions/checkout@v3
         with:
           lfs: true
           ref: submit
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
-          cache: 'pip' # caching pip dependencies
+          python-version: "3.8"
+          cache: "pip" # caching pip dependencies
       - run: |
           day=$(date +"%u")
           echo "DOWEEK=$((day))" >> $GITHUB_ENV
 
       - name: Skipping now
-        if: env.DOWEEK == 7  # sunday
+        if: env.DOWEEK == 7 # sunday
         run: echo "Skipping report now. Will be generated on next scheduled run!"
 
       - name: Install requirements
         if: env.DOWEEK != 7
         run: pip install -r requirements.txt
-      
+
       - name: Execute notebook
         if: env.DOWEEK != 7
         run: jupyter nbconvert --to html --no-input --execute --output index.html evaluation_report.ipynb
-        
+
       - name: Commit & push changes
         if: env.DOWEEK != 7
         run: |
@@ -73,9 +71,8 @@ jobs:
           -H "Accept: application/vnd.github+json" \
           /repos/$OWNER/$REPO/pulls/${{env.PR_TO_MERGE}}/merge \
           -f commit_title='Merge new report' \
-          -f commit_message='Automatically merge pull request from report pipeline' 
+          -f commit_message='Automatically merge pull request from report pipeline'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
-     

--- a/.github/workflows/manual_report_trigger.yml
+++ b/.github/workflows/manual_report_trigger.yml
@@ -1,19 +1,13 @@
 name: Manual report trigger
 
-# Controls when the workflow will run
 on:
-  # Allows you to run this workflow manually from the Actions tab
+  # Lets you pass inputs to workflows when manually triggering them from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   trigger:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Runs a single command using the runners shell
       - name: Run a one-line command
         run: echo "Report generation manually triggered"

--- a/.github/workflows/manual_trigger.yml
+++ b/.github/workflows/manual_trigger.yml
@@ -1,21 +1,13 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Manual eval trigger
 
-# Controls when the workflow will run
 on:
-  # Allows you to run this workflow manually from the Actions tab
+  # Lets you pass inputs to workflows when manually triggering them from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   trigger:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Runs a single command using the runners shell
       - name: Run a one-line script
         run: echo "Evaluation manually triggered"

--- a/.github/workflows/pr_evaluation.yml
+++ b/.github/workflows/pr_evaluation.yml
@@ -1,40 +1,32 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Check PullRequest
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
+  # Triggers the workflow on pull request events but only for the "submit" branch
   pull_request_target:
-    branches: [ "submit" ]
+    branches: ["submit"]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   check_PR:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
-          cache: 'pip' # caching pip dependencies
+          python-version: "3.9"
+          cache: "pip" # caching pip dependencies
       - run: pip install -r requirements.txt
-      
+
       - name: Check submission PR
         run: python scripts/check_submission.py
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      
+
       #- name: add label to PR
       #  uses: andymckay/labeler@master
       #  with:
       #    add-labels: "automerge"
-          
+
       # merge PR, if steps have not thrown errors yet
       - id: automerge
         name: automerge

--- a/.github/workflows/scheduled_trigger.yml
+++ b/.github/workflows/scheduled_trigger.yml
@@ -1,22 +1,15 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Scheduled eval trigger
 
 # Controls when the workflow will run
 on:
-  # Allows you to run this workflow manually from the Actions tab
   schedule:
     - cron: '39 8 * * *' # every morning
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   trigger:
-    # The type of runner that the job will run on
+  if: github.repository_owner == 'rki-daki-fws'
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Runs a single command using the runners shell
       - name: Run a one-line script
         run: echo "Evaluation triggered on schedule"

--- a/.github/workflows/scheduled_trigger.yml
+++ b/.github/workflows/scheduled_trigger.yml
@@ -3,11 +3,11 @@ name: Scheduled eval trigger
 # Controls when the workflow will run
 on:
   schedule:
-    - cron: '39 8 * * *' # every morning
+    - cron: "39 8 * * *" # every morning
 
 jobs:
   trigger:
-  if: github.repository_owner == 'rki-daki-fws'
+    if: github.repository_owner == 'rki-daki-fws'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
GitHub Actions run frequently although I only have a fork to participate in the competition. This commit makes these jobs dependable on the repository owner such that only the main repo of the competition will trigger the actions.

Furthermore, this commit removes redundant or incorrect comments and makes small formatting adjustments.